### PR TITLE
unset badge by passing badge=0

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -192,7 +192,7 @@ class Payload(object):
                 d['alert'] = self.alert
         if self.sound:
             d['sound'] = self.sound
-        if self.badge:
+        if self.badge is not None:
             d['badge'] = int(self.badge)
 
         d = { 'aps': d }

--- a/tests.py
+++ b/tests.py
@@ -147,6 +147,13 @@ class TestAPNs(unittest.TestCase):
         self.assertTrue('alert' not in d['aps'])
         self.assertTrue('sound' not in d['aps'])
 
+        # Payload with just badge removal
+        p = Payload(badge=0)
+        d = p.dict()
+        self.assertTrue('badge' in d['aps'])
+        self.assertTrue('alert' not in d['aps'])
+        self.assertTrue('sound' not in d['aps'])
+
         # Test plain string alerts
         alert_str = 'foobar'
         p = Payload(alert=alert_str)


### PR DESCRIPTION
It doesn't seem possible to unset the badge once pushed. The apple docs claim that

> If this property is absent, any badge number currently shown is removed

 -- https://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1

but this turns out not to be the case. Or maybe I'm mis-understanding what you're sending to the server. All I now is, in practice, this patch lets me unset badge numbers.
