### PR TITLE
Added support of the enhanced notification format

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -144,7 +144,7 @@ class APNsConnection(object):
 
 
 class PayloadAlert(object):
-    def __init__(self, body, action_loc_key=None, loc_key=None,
+    def __init__(self, body=None, action_loc_key=None, loc_key=None,
                  loc_args=None, launch_image=None):
         super(PayloadAlert, self).__init__()
         self.body = body
@@ -154,7 +154,9 @@ class PayloadAlert(object):
         self.launch_image = launch_image
 
     def dict(self):
-        d = { 'body': self.body }
+        d = {}
+        if self.body:
+            d['body'] = self.body
         if self.action_loc_key:
             d['action-loc-key'] = self.action_loc_key
         if self.loc_key:


### PR DESCRIPTION
The Apple Push Notification Service has an "enhanced notification format".
When this format is used, the gateway server responses with a detailed error instead of just ignoring the request.
This commit adds support for this feature, which includes raising exceptions depended on the server response.