### PR TITLE
Include payload size in PayloadTooLargeError

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -164,8 +164,9 @@ class PayloadAlert(object):
         return d
 
 class PayloadTooLargeError(Exception):
-    def __init__(self):
+    def __init__(self, payload_size):
         super(PayloadTooLargeError, self).__init__()
+        self.payload_size = payload_size
 
 class Payload(object):
     """A class representing an APNs message payload"""
@@ -200,8 +201,9 @@ class Payload(object):
         return json.dumps(self.dict(), separators=(',',':'), ensure_ascii=False).encode('utf-8')
 
     def _check_size(self):
-        if len(self.json()) > MAX_PAYLOAD_LENGTH:
-            raise PayloadTooLargeError()
+        payload_length = len(self.json())
+        if payload_length > MAX_PAYLOAD_LENGTH:
+            raise PayloadTooLargeError(payload_length)
 
     def __repr__(self):
         attrs = ("alert", "badge", "sound", "custom")


### PR DESCRIPTION
Currently, there is no information about the payload size when a PayloadTooLargeError is raised. It is kind of helpful to know this when an exception is raised so that application developer can use this info for logging or cutting down the payload. 
