### PR TITLE
make PayloadAlert body parameter optional since loc_key can be provided instead

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -142,7 +142,7 @@ class APNsConnection(object):
 
 
 class PayloadAlert(object):
-    def __init__(self, body, action_loc_key=None, loc_key=None,
+    def __init__(self, body='', action_loc_key=None, loc_key=None,
                  loc_args=None, launch_image=None):
         super(PayloadAlert, self).__init__()
         self.body = body
@@ -152,11 +152,13 @@ class PayloadAlert(object):
         self.launch_image = launch_image
 
     def dict(self):
-        d = { 'body': self.body }
+        if not self.loc_key:
+            d = {'body': self.body}
+        else:
+            d = {'loc-key': self.loc_key}
+
         if self.action_loc_key:
             d['action-loc-key'] = self.action_loc_key
-        if self.loc_key:
-            d['loc-key'] = self.loc_key
         if self.loc_args:
             d['loc-args'] = self.loc_args
         if self.launch_image:


### PR DESCRIPTION
body and loc_key are mutually exclusive and body should be optional if loc_key is provided, otherwise the empty body takes up payload space which is already so constrained with APNs.
