### PR TITLE
Fixed for SSL handshake timeout

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -136,7 +136,7 @@ class APNsConnection(object):
             except:
                 raise
 
-		# Fallback for 'SSLError: _ssl.c:489: The handshake operation timed out'
+        # Fallback for 'SSLError: _ssl.c:489: The handshake operation timed out'
         for i in xrange(3):
             try:
                 self._ssl = wrap_socket(self._socket, self.key_file, self.cert_file)


### PR DESCRIPTION
Sometimes when APNS trying to reconnect to server, Socket timeout or
SSL handshake timeout error happened. This fixed the problem by
allowing 3 times both reconnection and hand-shakes.

  File "tasks/apns.py", line 144, in _connection
    self._connect()
  File "tasks/apns.py", line 135, in _connect
    self._ssl = wrap_socket(self._socket, self.key_file, self.cert_file)
  File
"/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ssl.py"
, line 381, in wrap_socket
    ciphers=ciphers)
  File
"/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ssl.py"
, line 143, in __init__
    self.do_handshake()
  File
"/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ssl.py"
, line 305, in do_handshake
    self._sslobj.do_handshake()
SSLError: _ssl.c:489: The handshake operation timed out
