### PR TITLE
Fix Python 3 bytes-string Error

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -288,8 +288,8 @@ class GatewayConnection(APNsConnection):
         payload_length_bin = APNs.packed_ushort_big_endian(len(payload_json))
 
         zero_byte = '\0'
-	if sys.version_info[0] != 2:
-	    zero_byte = bytes(zero_byte, 'utf-8')
+        if sys.version_info[0] != 2:
+            zero_byte = bytes(zero_byte, 'utf-8')
         notification = (zero_byte + token_length_bin + token_bin
             + payload_length_bin + payload_json)
 


### PR DESCRIPTION
Since the library currently relies upon use of `str` as a byte type, an error is thrown when running Python 3, which switches the base string class away from `bytes`. The following error is thrown:

```
File ".../apns.py", line 288, in _get_notification
    + payload_length_bin + payload_json)
TypeError: Can't convert 'bytes' object to str implicitly
```

To resolve this, I added a check for the version of Python which switches the zero byte string to an explicitly defined `bytes` object if running Python 3.
