### PR TITLE
AttributeError: type object '_socketobject' has no attribute 'timeout'

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -25,7 +25,7 @@
 
 from binascii import a2b_hex, b2a_hex
 from datetime import datetime
-from socket import socket, AF_INET, SOCK_STREAM
+from socket import socket, timeout, AF_INET, SOCK_STREAM
 from struct import pack, unpack
 import sys
 
@@ -139,7 +139,7 @@ class APNsConnection(object):
                 self._socket.settimeout(self.timeout)
                 self._socket.connect((self.server, self.port))
                 break
-            except socket.timeout:
+            except timeout:
                 pass
             except:
                 raise


### PR DESCRIPTION
python-env/lib/python2.7/site-packages/apns.py", line 142, in _connect
    except socket.timeout:
AttributeError: type object '_socketobject' has no attribute 'timeout'
