### PR TITLE
Travis no longer support Python 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: python
 python:
   - "2.7"
   - "2.6"
-  - "2.5"
 install: "pip install -r requirements.txt"
 script: "python tests.py"


### PR DESCRIPTION
Listed Python 2.5 on .travis.yml but it doesn't work.
http://docs.travis-ci.com/user/ci-environment/#Python-VM-images
