### PR TITLE
change PayloadAlert to allow an alert which doesn't have any bodies

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -175,7 +175,7 @@ class APNsConnection(object):
 
 
 class PayloadAlert(object):
-    def __init__(self, body, action_loc_key=None, loc_key=None,
+    def __init__(self, body=None, action_loc_key=None, loc_key=None,
                  loc_args=None, launch_image=None):
         super(PayloadAlert, self).__init__()
         self.body = body
@@ -185,7 +185,9 @@ class PayloadAlert(object):
         self.launch_image = launch_image
 
     def dict(self):
-        d = { 'body': self.body }
+        d = {}
+        if self.body:
+            d['body'] = self.body
         if self.action_loc_key:
             d['action-loc-key'] = self.action_loc_key
         if self.loc_key:

--- a/tests.py
+++ b/tests.py
@@ -125,6 +125,11 @@ class TestAPNs(unittest.TestCase):
         self.assertEqual(d['loc-args'], ['king','kong'])
         self.assertEqual(d['launch-image'], 'wobble')
 
+        pa = PayloadAlert(loc_key='wibble')
+        d = pa.dict()
+        self.assertTrue('body' not in d)
+        self.assertEqual(d['loc-key'], 'wibble')
+
     def testPayload(self):
         # Payload with just alert
         p = Payload(alert=PayloadAlert('foo'))


### PR DESCRIPTION
The current implementation of PayloadAlert requires "body", but the alert attribute of payload doesn't require it like the following (this example is from https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html):

```
{
    "aps" : {
        "alert" : {
            "loc-key" : "GAME_PLAY_REQUEST_FORMAT",
            "loc-args" : [ "Jenna", "Frank"]
        },
        "sound" : "chime"
    },
    "acme" : "foo"
}
```

We can pass None to "body" of course but it uses wasteful bytes of payload. It is not good since the payload has length limitation.
