### PR TITLE
added --sandbox & --key-file options

### DIFF
--- a/apns-send
+++ b/apns-send
@@ -10,6 +10,10 @@ parser.add_option("-c", "--certificate-file",
                   dest="certificate_file",
                   help="Path to .pem certificate file")
 
+parser.add_option("-k", "--key-file",
+                  dest="key_file",
+                  help="Path to .pem key file")
+
 parser.add_option("-p", "--push-token",
                   dest="push_token",
                   help="Push token")
@@ -17,6 +21,10 @@ parser.add_option("-p", "--push-token",
 parser.add_option("-m", "--message",
                   dest="message",
                   help="Message")
+
+parser.add_option("-s", "--sandbox",
+                  action="store_true", dest="sandbox", default=False,
+                  help="Use apple sandbox (dev push certificates)")
 
 options, args = parser.parse_args()
 
@@ -29,7 +37,7 @@ if options.push_token is None:
 if options.message is None:
     parser.error('Must provide --message')
 
-apns = APNs(cert_file=options.certificate_file)
+apns = APNs(use_sandbox=options.sandbox, cert_file=options.certificate_file, key_file=options.key_file)
 
 # Send a notification
 payload = Payload(alert=options.message, sound="default", badge=1)


### PR DESCRIPTION
After using you're great lib I realized it was missing a few simple features especially on the `apns-send` CLI tool:
- A key-file option to specify where the key is stored
- A sandbox option to force the usage of apple sandbox for dev push certificates

Let me know if you have any questions