### PR TITLE
Add 0.1s sleep to read error response loop to avoid crazy looping

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -525,6 +525,7 @@ class GatewayConnection(APNsConnection):
     
     def _read_error_response(self):
         while not self._close_read_thread:
+            time.sleep(0.1) #avoid crazy loop if something bad happened. e.g. using invalid certificate
             while not self.connection_alive:
                 time.sleep(0.1)
             


### PR DESCRIPTION
Add 0.1s sleep to read error response loop to avoid crazy looping cause by keep receiving unmeaningful data from apns. e.g. using certificate from invalid provisioning profile will make apns send 0 length data to read socket.
