### PR TITLE
Prepare package for v2.0.1 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     py_modules = ['apns'],
     scripts = ['apns-send'],
     url = 'http://www.goosoftware.co.uk/',
-    version = '2.0.0',
+    version = '2.0.1',
 )


### PR DESCRIPTION
The most important change in this release is the fix for the `apns-send` error when attempting to `pip install` this package.

Ping @djacobs and @simonwhitaker who are the people able to push a new version of this package.