### PR TITLE
Python 3 compatibility

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -195,7 +195,7 @@ class APNsConnection(object):
         _logger.debug("%s APNS connection establishing..." % self.__class__.__name__)
 
         # Fallback for socket timeout.
-        for i in xrange(3):
+        for i in range(3):
             try:
                 self._socket = socket(AF_INET, SOCK_STREAM)
                 self._socket.settimeout(self.timeout)
@@ -215,7 +215,7 @@ class APNsConnection(object):
                 try:
                     self._ssl.do_handshake()
                     break
-                except ssl.SSLError, err:
+                except ssl.SSLError as err:
                     if ssl.SSL_ERROR_WANT_READ == err.args[0]:
                         select.select([self._ssl], [], [])
                     elif ssl.SSL_ERROR_WANT_WRITE == err.args[0]:
@@ -225,11 +225,11 @@ class APNsConnection(object):
 
         else:
             # Fallback for 'SSLError: _ssl.c:489: The handshake operation timed out'
-            for i in xrange(3):
+            for i in range(3):
                 try:
                     self._ssl = wrap_socket(self._socket, self.key_file, self.cert_file)
                     break
-                except SSLError, ex:
+                except SSLError as ex:
                     if ex.args[0] == SSL_ERROR_WANT_READ:
                         sys.exc_clear()
                     elif ex.args[0] == SSL_ERROR_WANT_WRITE:
@@ -363,36 +363,36 @@ class Frame(object):
     def add_item(self, token_hex, payload, identifier, expiry, priority):
         """Add a notification message to the frame"""
         item_len = 0
-        self.frame_data.extend('\2' + APNs.packed_uint_big_endian(item_len))
+        self.frame_data.extend(b'\2' + APNs.packed_uint_big_endian(item_len))
 
         token_bin = a2b_hex(token_hex)
         token_length_bin = APNs.packed_ushort_big_endian(len(token_bin))
-        token_item = '\1' + token_length_bin + token_bin
+        token_item = b'\1' + token_length_bin + token_bin
         self.frame_data.extend(token_item)
         item_len += len(token_item)
 
         payload_json = payload.json()
         payload_length_bin = APNs.packed_ushort_big_endian(len(payload_json))
-        payload_item = '\2' + payload_length_bin + payload_json
+        payload_item = b'\2' + payload_length_bin + payload_json
         self.frame_data.extend(payload_item)
         item_len += len(payload_item)
 
         identifier_bin = APNs.packed_uint_big_endian(identifier)
         identifier_length_bin = \
                 APNs.packed_ushort_big_endian(len(identifier_bin))
-        identifier_item = '\3' + identifier_length_bin + identifier_bin
+        identifier_item = b'\3' + identifier_length_bin + identifier_bin
         self.frame_data.extend(identifier_item)
         item_len += len(identifier_item)
 
         expiry_bin = APNs.packed_uint_big_endian(expiry)
         expiry_length_bin = APNs.packed_ushort_big_endian(len(expiry_bin))
-        expiry_item = '\4' + expiry_length_bin + expiry_bin
+        expiry_item = b'\4' + expiry_length_bin + expiry_bin
         self.frame_data.extend(expiry_item)
         item_len += len(expiry_item)
 
         priority_bin = APNs.packed_uchar(priority)
         priority_length_bin = APNs.packed_ushort_big_endian(len(priority_bin))
-        priority_item = '\5' + priority_length_bin + priority_bin
+        priority_item = b'\5' + priority_length_bin + priority_bin
         self.frame_data.extend(priority_item)
         item_len += len(priority_item)
 
@@ -432,7 +432,7 @@ class FeedbackConnection(APNsConnection):
         A generator that yields (token_hex, fail_time) pairs retrieved from
         the APNs feedback server
         """
-        buff = ''
+        buff = b''
         for chunk in self._chunks():
             buff += chunk
 
@@ -526,7 +526,7 @@ class GatewayConnection(APNsConnection):
             message = self._get_enhanced_notification(token_hex, payload,
                                                            identifier, expiry)
             
-            for i in xrange(WRITE_RETRY):
+            for i in range(WRITE_RETRY):
                 try:
                     with self._send_lock:
                         self._make_sure_error_response_handler_worker_alive()
@@ -548,7 +548,7 @@ class GatewayConnection(APNsConnection):
             or not self._error_response_handler_worker.is_alive()):
             self._init_error_response_handler_worker()
             TIMEOUT_SEC = 10
-            for _ in xrange(TIMEOUT_SEC):
+            for _ in range(TIMEOUT_SEC):
                 if self._error_response_handler_worker.is_alive():
                     _logger.debug("error response handler worker is running")
                     return


### PR DESCRIPTION
This commit takes the current version and makes it compatible with Python 3 (#85). Nothing too complicated. 2to3 does most of the work.

There are no major changes in apns.py, just syntax and explicitly made some parts of the codes bytes to compatible across 2 and 3.

Similar in tests.py. Only line 191-193 needed a small change to account for different ordered dictionaries. An alternative could be test the beginning of the line, the end of the line, and json parse the middle and compare.