### PR TITLE
(fix) #108: Missing _sent_notifications

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -480,7 +480,7 @@ class GatewayConnection(APNsConnection):
             self._error_response_handler_worker = None
             self._response_listener = None
             
-            self._sent_notifications = collections.deque(maxlen=SENT_BUFFER_QTY)
+        self._sent_notifications = collections.deque(maxlen=SENT_BUFFER_QTY)
 
     def _init_error_response_handler_worker(self):
         self._send_lock = threading.RLock()


### PR DESCRIPTION
Define self._sent_notifications even when not using enhanced. Problem is that _sent_notifications is used in send_notification_multiple since f33faf79de5e36a7b983b0a318bd2a7e7f99e3a7
Fixes #108 