### PR TITLE
Made fix for Python 2.6.6, which doesn't allow write() to use bytearrays

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -557,7 +557,7 @@ class GatewayConnection(APNsConnection):
 
     def send_notification_multiple(self, frame):
         self._sent_notifications += frame.get_notifications(self)
-        return self.write(frame.get_frame())
+        return self.write(bytes(frame.get_frame()))
     
     def register_response_listener(self, response_listener):
         self._response_listener = response_listener


### PR DESCRIPTION
The library doesn't fully work with Python 2.6.6 (and most likely Python 2.6 in general), because the write() method in the ssl socket library does not support using bytearray to write from. This fix should fix this problem and still work in all other versions of Python.