### PR TITLE
allow wait time after a socket error to be patched if needed.

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -88,6 +88,8 @@ SENT_BUFFER_QTY = 100000
 WAIT_WRITE_TIMEOUT_SEC = 10
 WAIT_READ_TIMEOUT_SEC = 10
 WRITE_RETRY = 3
+SOCKET_ERR_RETRY_WAIT_DEFAULT = 10
+
 
 ER_STATUS = 'status'
 ER_IDENTIFER = 'identifier'
@@ -534,7 +536,7 @@ class GatewayConnection(APNsConnection):
                         self._sent_notifications.append(dict({'id': identifier, 'message': message}))
                     break
                 except socket_error as e:
-                    delay = 10 + (i * 2)
+                    delay = SOCKET_ERR_RETRY_WAIT_DEFAULT + (i * 2)
                     _logger.exception("sending notification with id:" + str(identifier) + 
                                  " to APNS failed: " + str(type(e)) + ": " + str(e) + 
                                  " in " + str(i+1) + "th attempt, will wait " + str(delay) + " secs for next action")


### PR DESCRIPTION
I see socket error 107 crop up in my logs frequently and it is always only that first iteration. 

```
apns ERROR sending notification with id:2282941054 to APNS failed: <class 'socket.error'>: [Errno 115] Operation now in progress in 1th attempt, will wait 10 secs for next action
```

10 secs to sit idly seems like a really long time, especially on the first retry. 

Subsequent calls happen quickly with no problems. However I understand that this default may be sane for most people so I'm fine with leaving that value. I'd just like to be able to monkey patch it easily and get rid of the magic constant value hidden deep in the code.
