### PR TITLE
remove __del__ from APNsConnection to prevent memory leak

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -187,9 +187,6 @@ class APNsConnection(object):
         self.enhanced = enhanced
         self.connection_alive = False
 
-    def __del__(self):
-        self._disconnect();
-
     def _connect(self):
         # Establish an SSL connection
         _logger.debug("%s APNS connection establishing..." % self.__class__.__name__)


### PR DESCRIPTION
`__del__` should not be implemented with circular references as it prevents those objects to be garbage collected. In enhanced mode, this method is never called and it does not allows garbage collector to clean the old objects causing memory to grow in long process applications