### PR TITLE
FIXED: Error while sending multicast without 'enhanced'.

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -480,7 +480,7 @@ class GatewayConnection(APNsConnection):
             self._error_response_handler_worker = None
             self._response_listener = None
             
-            self._sent_notifications = collections.deque(maxlen=SENT_BUFFER_QTY)
+        self._sent_notifications = collections.deque(maxlen=SENT_BUFFER_QTY)
 
     def _init_error_response_handler_worker(self):
         self._send_lock = threading.RLock()


### PR DESCRIPTION
I have many `token_hex` in my database to which I want to send multicast. But it is possible to have invalid token_hex values (as I get them through an API), due to which I need to set `enhanced = False` in my code. Setting it to `True` stops sending the multicast without any Exception. So when `enhanced = False`, I get the error

`
AttributeError: 'GatewayConnection' object has no attribute '_sent_notifications'
`
in sending multicast (send_notification_multiple) as `_sent_notifications` is not initialized when `self.enhanced` is not set to `True` in `class GatewayConnection`.

Fixed by putting `self._sent_notifications` initialization outside `self.enhanced == True` check in the `GatewayConnection` class.

