### PR TITLE
Enable unicode emoji in APNS messages

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -339,7 +339,7 @@ class Payload(object):
         return d
 
     def json(self):
-        return json.dumps(self.dict(), separators=(',',':'), ensure_ascii=False).encode('utf-8')
+        return json.dumps(self.dict(), separators=(',',':'), ensure_ascii=True).encode('utf-8')
 
     def _check_size(self):
         payload_length = len(self.json())


### PR DESCRIPTION
Refs #127 - this change allows unicode Emoji sequences to be sent as push notification banners, e.g.:

    Payload({"alert": u"This has emoji! \u1F4A9"})