### PR TITLE
Remove dependency on simplejson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: python
 python:
   - "2.7"
   - "2.6"
-install: "pip install -r requirements.txt"
 script: "python tests.py"

--- a/apns.py
+++ b/apns.py
@@ -42,10 +42,7 @@ except ImportError:
 
 from _ssl import SSL_ERROR_WANT_READ, SSL_ERROR_WANT_WRITE
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
+import json
 
 _logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-simplejson==2.6.1 # Not required on Python 2.6+


### PR DESCRIPTION
Python has the `json` module from version 2.6 onwards. So we don't need `simplejson`. `simplejson` is PyAPNs' only external dependency now and removing it will make it completely independent of external libraries.

The version of `simplejson` in the requirements file is so old that it doesn't install on python 3.4. We would have anyways had to change it. I think it's better if we just remove it.