### PR TITLE
Handle errors for multiple push notification

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -556,7 +556,8 @@ class GatewayConnection(APNsConnection):
             _logger.warning("error response handler worker is not started after %s secs" % TIMEOUT_SEC)
 
     def send_notification_multiple(self, frame):
-        self._make_sure_error_response_handler_worker_alive()
+        if self.enhanced:
+            self._make_sure_error_response_handler_worker_alive()
         self._sent_notifications += frame.get_notifications(self)
         return self.write(frame.get_frame())
 

--- a/apns.py
+++ b/apns.py
@@ -556,6 +556,7 @@ class GatewayConnection(APNsConnection):
             _logger.warning("error response handler worker is not started after %s secs" % TIMEOUT_SEC)
 
     def send_notification_multiple(self, frame):
+        self._make_sure_error_response_handler_worker_alive()
         self._sent_notifications += frame.get_notifications(self)
         return self.write(frame.get_frame())
 


### PR DESCRIPTION
Errors should be handled while sending multiple push notification.

Currently , errors now are handled when sending one push notification, but not for multiple push notification.