### PR TITLE
Add 'thread-id' into Payload class

### DIFF
--- a/apns.py
+++ b/apns.py
@@ -306,13 +306,13 @@ class PayloadTooLargeError(Exception):
 
 class Payload(object):
     """A class representing an APNs message payload"""
-    def __init__(self, alert=None, badge=None, sound=None, category=None, custom=None, content_available=False,
-                 mutable_content=False):
+    def __init__(self, alert=None, badge=None, sound=None, thread_id=None, category=None, custom=None, content_available=False, mutable_content=False):
         super(Payload, self).__init__()
         self.alert = alert
         self.badge = badge
         self.sound = sound
         self.category = category
+        self.thread_id = thread_id
         self.custom = custom
         self.content_available = content_available
         self.mutable_content = mutable_content
@@ -334,6 +334,8 @@ class Payload(object):
             d['badge'] = int(self.badge)
         if self.category:
             d['category'] = self.category
+        if self.thread_id:
+            d['thread-id'] = self.thread_id
 
         if self.content_available:
             d.update({'content-available': 1})
@@ -355,7 +357,7 @@ class Payload(object):
             raise PayloadTooLargeError(payload_length)
 
     def __repr__(self):
-        attrs = ("alert", "badge", "sound", "category", "custom")
+        attrs = ("alert", "badge", "sound", "thread-id", "category", "custom")
         args = ", ".join(["%s=%r" % (n, getattr(self, n)) for n in attrs])
         return "%s(%s)" % (self.__class__.__name__, args)
 


### PR DESCRIPTION
Update key 'thread-id', which was added by Apple to separate notifications by thread, in Payload class.